### PR TITLE
Add Protected Mode to Lockbox

### DIFF
--- a/lib/lockbox.rb
+++ b/lib/lockbox.rb
@@ -28,12 +28,24 @@ module Lockbox
 
   class << self
     attr_accessor :default_options
-    attr_writer :master_key
+    attr_writer :master_key, :protected_mode
   end
   self.default_options = {}
 
   def self.master_key
     @master_key ||= ENV["LOCKBOX_MASTER_KEY"]
+  end
+
+  def self.protected_mode
+    @protected_mode ||= false
+  end
+
+  def self.enable_protected_mode
+    self.protected_mode = true
+  end
+
+  def self.disable_protected_mode
+    self.protected_mode = false
   end
 
   def self.migrate(relation, batch_size: 1000, restart: false)

--- a/lib/lockbox/calculations.rb
+++ b/lib/lockbox/calculations.rb
@@ -19,6 +19,7 @@ module Lockbox
 
       # pluck
       result = super(*column_names)
+      return result if Lockbox.protected_mode
 
       # decrypt result
       # handle pluck to single columns and multiple

--- a/lib/lockbox/encryptor.rb
+++ b/lib/lockbox/encryptor.rb
@@ -20,6 +20,8 @@ module Lockbox
     end
 
     def decrypt(ciphertext, **options)
+      return ciphertext if Lockbox.protected_mode
+
       ciphertext = Base64.decode64(ciphertext) if @encode
       ciphertext = check_string(ciphertext)
 

--- a/test/carrier_wave_test.rb
+++ b/test/carrier_wave_test.rb
@@ -1,6 +1,10 @@
 require_relative "test_helper"
 
 class CarrierWaveTest < Minitest::Test
+  def setup
+    Lockbox.disable_protected_mode
+  end
+
   def teardown
     @content = nil
   end

--- a/test/model_protected_test.rb
+++ b/test/model_protected_test.rb
@@ -1,0 +1,153 @@
+require_relative "test_helper"
+
+class ModelTest < Minitest::Test
+  def setup
+    User.delete_all
+    @name = 'name'
+    @email = "test@example.org"
+    User.create!(email: @email, name: @name)
+    Lockbox.enable_protected_mode
+  end
+
+  def teardown
+    # very important!!
+    # ensure no plaintext attributes exist
+    assert_no_plaintext_attributes if mongoid?
+    Lockbox.disable_protected_mode
+  end
+
+  def test_access_protected_mode
+    user = User.last
+    refute_equal @email, user.email
+    assert_equal user.email_ciphertext, user.email
+  end
+
+  def test_decrypt_after_destroy
+    user = User.last
+    user.destroy!
+
+    refute_equal @email, user.email
+    assert_equal user.email_ciphertext, user.email
+  end
+
+  def test_update_unencrypted_attribute
+    user = User.last
+    new_name = 'othername'
+    result = user.update(name: 'othername')
+    assert result
+    assert_equal new_name, user.name
+  end
+
+  def test_update_encrypted_attribute
+    user = User.last
+    new_email = 'other@email.com'
+    result = user.update(email: new_email)
+
+    refute result
+    refute_equal new_email, user.email
+    refute_equal @email, user.email
+  end
+
+  def test_update_with_error_encrypted_attribute
+    user = User.last
+    new_email = 'other@email.com'
+
+    assert_raises(Lockbox::Error) do
+      user.update!(email: new_email)
+    end
+  end
+
+  def test_save_with_encrypted_attribute
+    new_email = 'other@email.com'
+    user = User.last
+    user.email = new_email
+    result = user.save
+
+    refute result
+    refute_equal new_email, user.email
+    refute_equal @email, user.email
+  end
+
+  def test_save_with_error_with_encrypted_attribute
+    new_email = 'other@email.com'
+    user = User.last
+    user.email = new_email
+
+    assert_raises(Lockbox::Error) do
+      user.save!
+    end
+  end
+
+  def test_update_columns_encrypted_attributes
+    new_email = 'otheremail@email.com'
+    user = User.last
+    user.update_column(:email, new_email)
+
+    Lockbox.disable_protected_mode
+    assert_equal user.email, new_email
+  end
+
+  def test_changes
+    new_email = 'otheremail@email.com'
+    new_name = 'othername'
+    user = User.last
+    user.name = new_name
+    user.email = new_email
+
+    user_changes = user.changes
+
+    refute_includes user_changes, @email, new_email
+    assert_includes user_changes, @name, new_name
+  end
+
+  def test_create_method
+    assert_raises(Lockbox::Error) do
+      User.create!(name: 'othertest', email: 'other@email.com')
+    end
+  end
+
+  def test_decrypt_method
+    key = Lockbox.attribute_key(table: "users", attribute: "encrypted_email")
+    box = Lockbox.new(key: key, encode: true)
+    user = User.last
+
+    assert_equal user.email_ciphertext, box.decrypt(user.email_ciphertext)
+    assert_equal user.email, box.decrypt(user.email_ciphertext)
+  end
+
+  def test_pluck_with_encrypted_attributes
+    other_email = 'other@email.com'
+    Lockbox.disable_protected_mode
+    User.create!(name: 'othertest', email: other_email)
+    Lockbox.enable_protected_mode
+
+    assert_equal User.pluck(:email).count, 2
+
+    refute_includes User.pluck(:email), @email, other_email
+    assert_equal User.pluck(:email), User.pluck(:email_ciphertext)
+  end
+
+  def test_pluck_with_unencrypted_attributes
+    other_name = 'othername'
+    other_email = 'other@email.com'
+    Lockbox.disable_protected_mode
+    User.create!(name: other_name, email: other_email)
+    Lockbox.enable_protected_mode
+
+    assert_equal User.pluck(:name).count, 2
+
+    assert_includes User.pluck(:name), @name, other_name
+  end
+
+  def test_pluck_with_multiple_attributes
+    other_name = 'othername'
+    other_email = 'other@email.com'
+    Lockbox.disable_protected_mode
+    User.create!(name: other_name, email: other_email)
+    Lockbox.enable_protected_mode
+
+    assert_equal User.pluck(:name, :email).count, 2
+
+    assert_includes User.pluck(:name), [[@name, @email], [other_name, other_email]]
+  end
+end

--- a/test/model_protected_test.rb
+++ b/test/model_protected_test.rb
@@ -3,27 +3,34 @@ require_relative "test_helper"
 class ModelTest < Minitest::Test
   def setup
     User.delete_all
-    @name = 'name'
-    @email = "test@example.org"
-    User.create!(email: @email, name: @name)
-    Lockbox.enable_protected_mode
   end
 
   def teardown
     # very important!!
     # ensure no plaintext attributes exist
-    assert_no_plaintext_attributes if mongoid?
     Lockbox.disable_protected_mode
+    assert_no_plaintext_attributes if mongoid?
+  end
+
+  def create_user
+    @name = "name"
+    @email = "test@example.org"
+    User.create!(email: email, name: @name)
+    Lockbox.enable_protected_mode
   end
 
   def test_access_protected_mode
-    user = User.last
-    refute_equal @email, user.email
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
+    refute_equal email, user.email
     assert_equal user.email_ciphertext, user.email
   end
 
   def test_decrypt_after_destroy
-    user = User.last
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
     user.destroy!
 
     refute_equal @email, user.email
@@ -31,26 +38,32 @@ class ModelTest < Minitest::Test
   end
 
   def test_update_unencrypted_attribute
-    user = User.last
-    new_name = 'othername'
-    result = user.update(name: 'othername')
+    email = "test@example.org"
+    user = User.create!(email: email, name: "name")
+    Lockbox.enable_protected_mode
+    new_name = "othername"
+    result = user.update(name: "othername")
     assert result
     assert_equal new_name, user.name
   end
 
   def test_update_encrypted_attribute
-    user = User.last
-    new_email = 'other@email.com'
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
+    new_email = "other@email.com"
     result = user.update(email: new_email)
 
     refute result
     refute_equal new_email, user.email
-    refute_equal @email, user.email
+    refute_equal email, user.email
   end
 
   def test_update_with_error_encrypted_attribute
-    user = User.last
-    new_email = 'other@email.com'
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
+    new_email = "other@email.com"
 
     assert_raises(Lockbox::Error) do
       user.update!(email: new_email)
@@ -58,19 +71,23 @@ class ModelTest < Minitest::Test
   end
 
   def test_save_with_encrypted_attribute
-    new_email = 'other@email.com'
-    user = User.last
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
+    new_email = "other@email.com"
     user.email = new_email
     result = user.save
 
     refute result
     refute_equal new_email, user.email
-    refute_equal @email, user.email
+    refute_equal email, user.email
   end
 
   def test_save_with_error_with_encrypted_attribute
-    new_email = 'other@email.com'
-    user = User.last
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
+    new_email = "other@email.com"
     user.email = new_email
 
     assert_raises(Lockbox::Error) do
@@ -79,8 +96,10 @@ class ModelTest < Minitest::Test
   end
 
   def test_update_columns_encrypted_attributes
-    new_email = 'otheremail@email.com'
-    user = User.last
+    email = "test@example.org"
+    user = User.create!(email: email)
+    Lockbox.enable_protected_mode
+    new_email = "otheremail@email.com"
     user.update_column(:email, new_email)
 
     Lockbox.disable_protected_mode
@@ -88,66 +107,72 @@ class ModelTest < Minitest::Test
   end
 
   def test_changes
-    new_email = 'otheremail@email.com'
-    new_name = 'othername'
-    user = User.last
+    email = "test@example.org"
+    name = "name"
+    user = User.create!(email: email, name: name)
+    Lockbox.enable_protected_mode
+    new_email = "otheremail@email.com"
+    new_name = "othername"
+
     user.name = new_name
     user.email = new_email
-
     user_changes = user.changes
 
-    refute_includes user_changes, @email, new_email
-    assert_includes user_changes, @name, new_name
+    refute_includes user_changes["email"], email, new_email
+    assert_includes user_changes["name"], name, new_name
   end
 
   def test_create_method
+    Lockbox.enable_protected_mode
     assert_raises(Lockbox::Error) do
-      User.create!(name: 'othertest', email: 'other@email.com')
+      User.create!(name: "othertest", email: "other@email.com")
     end
   end
 
   def test_decrypt_method
+    user = User.create!(email: "test@example.org")
+    Lockbox.enable_protected_mode
     key = Lockbox.attribute_key(table: "users", attribute: "encrypted_email")
     box = Lockbox.new(key: key, encode: true)
-    user = User.last
 
     assert_equal user.email_ciphertext, box.decrypt(user.email_ciphertext)
     assert_equal user.email, box.decrypt(user.email_ciphertext)
   end
 
   def test_pluck_with_encrypted_attributes
-    other_email = 'other@email.com'
-    Lockbox.disable_protected_mode
-    User.create!(name: 'othertest', email: other_email)
+    email = "test@example.org"
+    other_email = "other@email.com"
+    User.create!(email: email)
+    User.create!(email: other_email)
     Lockbox.enable_protected_mode
 
     assert_equal User.pluck(:email).count, 2
 
-    refute_includes User.pluck(:email), @email, other_email
+    refute_includes User.pluck(:email), email, other_email
     assert_equal User.pluck(:email), User.pluck(:email_ciphertext)
   end
 
   def test_pluck_with_unencrypted_attributes
-    other_name = 'othername'
-    other_email = 'other@email.com'
-    Lockbox.disable_protected_mode
-    User.create!(name: other_name, email: other_email)
+    name = "name"
+    other_name = "othername"
+    User.create!(name: name)
+    User.create!(name: other_name)
     Lockbox.enable_protected_mode
 
     assert_equal User.pluck(:name).count, 2
 
-    assert_includes User.pluck(:name), @name, other_name
+    assert_includes User.pluck(:name), name, other_name
   end
 
   def test_pluck_with_multiple_attributes
-    other_name = 'othername'
-    other_email = 'other@email.com'
-    Lockbox.disable_protected_mode
-    User.create!(name: other_name, email: other_email)
+    name = "name"
+    other_name = "othername"
+    user = User.create!(name: name, email: "test@example.org")
+    user_2 = User.create!(name: other_name, email: "other@email.com")
     Lockbox.enable_protected_mode
 
     assert_equal User.pluck(:name, :email).count, 2
 
-    assert_includes User.pluck(:name), [[@name, @email], [other_name, other_email]]
+    assert_equal User.order(:id).pluck(:name, :email), [[user.name, user.email_ciphertext], [other_name, user_2.email_ciphertext]]
   end
 end

--- a/test/model_test.rb
+++ b/test/model_test.rb
@@ -2,6 +2,7 @@ require_relative "test_helper"
 
 class ModelTest < Minitest::Test
   def setup
+    Lockbox.disable_protected_mode
     User.delete_all
   end
 

--- a/test/model_types_test.rb
+++ b/test/model_types_test.rb
@@ -2,6 +2,7 @@ require_relative "test_helper"
 
 class ModelTypesTest < Minitest::Test
   def setup
+    Lockbox.disable_protected_mode
     skip if mongoid?
   end
 


### PR DESCRIPTION
What is protected mode? Protected mode is a mode inspired in activerecord method (`protecting_encrypted_data`) enable this mode will disable all capabilities of decrypting and create/save/update encrypted attributes in DB models. Updating unencrypted fields is allowed and it's successful on this mode.

**Changes**:

1. Add 2 methods (`enable/disable_protected_mode`) and it's accessor `protected_mode`
2. Update Model with Protected

   -  Add save and save! methods, verifies before saving if any encrypted method is detected from Lockbox
   -  Add changes method, overwritten to hide unecrypted attribute to his encrypted counterpart
   -  Update methods `#{name}`, does not decrypt when it's in protected mode
   -  Update decrypt merhod to not decrypt while it's in protected mode
   -  Update `name_change`, doesn't decrypt while in protected mode
 3. Update pluck to return only encrypted_attributes when in protected_mode
 4. Update encryptor to return ciphertext instead of decrypting it while in protected_mode
 5.  Add new test suite for protected models / pluck and encrypted.